### PR TITLE
Byron latimes calculate

### DIFF
--- a/pims-minimal/Dockerfile
+++ b/pims-minimal/Dockerfile
@@ -7,6 +7,8 @@ RUN conda install --yes astropy \
   boto \
   beautifulsoup4 \
   cartopy \
+  colorlover \
+  cvxopt \
   geos \
   gfortran_linux-64 \
   gmp \
@@ -20,10 +22,14 @@ RUN conda install --yes astropy \
   mpld3 \
   nltk \
   pandas=0.22* \
+  plotly \
   proj4 \
   pyqt \
   pysal \
+  qgrid \
+  rdflib \
   tensorflow \
+  textblob \
   lxml && \
   conda remove --quiet --yes --force qt pyqt && \
   conda clean -tipsy

--- a/pims-minimal/requirements.txt
+++ b/pims-minimal/requirements.txt
@@ -1,4 +1,5 @@
 geopandas
+latimes-calculate
 pdfdocument
 pivottablejs
 psutil


### PR DESCRIPTION
This PR adds some packages that Byron has requested to support teacher workshops. 

  * [colorlover](https://anaconda.org/conda-forge/colorlover)
  * [cvxopt](https://anaconda.org/conda-forge)
  * [plotly](https://anaconda.org/conda-forge/plotly)
  * [qgrid](https://anaconda.org/conda-forge)
  * [rdflib](https://anaconda.org/conda-forge)
  * [textblob](https://anaconda.org/conda-forge)

Most of them are available in anaconda except `latimes-calculate` which seems to be outdated, so I used [pypi/latimes-calculate](https://pypi.org/project/latimes-calculate/) instead.

The modifications should be contained to the python3 kernel. `make build-test-all` passes and I tested basic functionality of the kernel. If nothing else comes up, I'll merge and arrange deployment and verification with Byron on later this afternoon.