### PR TITLE
Ordinary user 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ endif
 
 ALL_IMAGES:=$(ALL_STACKS)
 
+ifeq ($(COMMIT),)
+	COMMIT := latest
+endif
+
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@echo "jupyter/docker-stacks"
@@ -63,10 +67,10 @@ test/%: ## run tests against a stack
 	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test
 
 test/base-notebook: ## test supported options in the base notebook
-	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test base-notebook/test
+	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test pims-minimal/test
 
 test/pims-r: ## re-run the base notebook tests in the pims-r container to ensure tests still pass
-	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test base-notebook/test
+	@TEST_IMAGE="$(OWNER)/$(notdir $@)" pytest test pims-minimal/test
 
 test/callysto-swift: ## ignore tests for swiftfs since it requires a functional swift environment
 	@echo ""

--- a/pims-minimal/Dockerfile
+++ b/pims-minimal/Dockerfile
@@ -47,6 +47,9 @@ RUN jupyter lab build
 RUN pip install git+https://github.com/data-8/nbgitpuller \
  && jupyter serverextension enable --sys-prefix nbgitpuller
 
+RUN mkdir -p /home/$NB_USER/.config/matplotlib \
+  && echo "backend: Agg" >> /home/$NB_USER/.config/matplotlib/matplotlibrc
+
 USER root
 # fetch juptyerhub-singleuser entrypoint
 RUN wget -q https://raw.githubusercontent.com/jupyterhub/jupyterhub/0.8.1/scripts/jupyterhub-singleuser -O /usr/local/bin/jupyterhub-singleuser && \
@@ -80,13 +83,14 @@ COPY pip.conf /etc/pip.conf
 
 ENV SHELL /bin/bash
 
-COPY systemuser.sh /srv/singleuser/systemuser.sh
-
 CMD ["bash", "/srv/singleuser/systemuser.sh"]
 
-RUN mkdir -p /opt/notebook/local_templates && mkdir -p /etc/jupyter
-COPY notebook.html /opt/notebook/local_templates/notebook.html
 COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
 
-RUN mkdir -p /home/$NB_USER/.config/matplotlib \
-  && echo "backend: Agg" >> /home/$NB_USER/.config/matplotlib/matplotlibrc
+RUN useradd -m -s /bin/bash -N -u 9999 jupyter
+  && echo "backend: Agg" >> /home/$NB_USER/.config/matplotlib/matplotlibrc	USER jupyter
+# Configure environment
+ENV NB_USER=jupyter \
+    NB_UID=9999
+ENV HOME=/home/$NB_USER
+WORKDIR $HOME

--- a/pims-minimal/Dockerfile
+++ b/pims-minimal/Dockerfile
@@ -83,14 +83,13 @@ COPY pip.conf /etc/pip.conf
 
 ENV SHELL /bin/bash
 
-CMD ["bash", "/srv/singleuser/systemuser.sh"]
-
 COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
 
 RUN useradd -m -s /bin/bash -N -u 9999 jupyter
-  && echo "backend: Agg" >> /home/$NB_USER/.config/matplotlib/matplotlibrc	USER jupyter
+USER jupyter
 # Configure environment
 ENV NB_USER=jupyter \
     NB_UID=9999
 ENV HOME=/home/$NB_USER
 WORKDIR $HOME
+

--- a/pims-minimal/test/test_container_options.py
+++ b/pims-minimal/test/test_container_options.py
@@ -1,0 +1,34 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import time
+
+import pytest
+
+
+def test_cli_args(container, http_client):
+    """Container should respect notebook server command line args
+    (e.g., disabling token security)"""
+    container.run(
+        command=['start-notebook.sh', '--NotebookApp.token=""']
+    )
+    resp = http_client.get('http://localhost:8888')
+    resp.raise_for_status()
+    assert 'login_submit' not in resp.text
+
+
+@pytest.mark.filterwarnings('ignore:Unverified HTTPS request')
+def test_unsigned_ssl(container, http_client):
+    """Container should generate a self-signed SSL certificate
+    and notebook server should use it to enable HTTPS.
+    """
+    container.run(
+        environment=['GEN_CERT=yes']
+    )
+    # NOTE: The requests.Session backing the http_client fixture does not retry
+    # properly while the server is booting up. An SSL handshake error seems to
+    # abort the retry logic. Forcing a long sleep for the moment until I have
+    # time to dig more.
+    time.sleep(5)
+    resp = http_client.get('https://localhost:8888', verify=False)
+    resp.raise_for_status()
+    assert 'login_submit' in resp.text

--- a/pims-r/Dockerfile
+++ b/pims-r/Dockerfile
@@ -5,6 +5,7 @@ FROM callysto/pims-minimal
 
 MAINTAINER Ian Allison <iana@pims.math.ca>
 
+# Configure environment
 ENV NB_USER=jovyan
 ENV HOME=/home/$NB_USER
 USER $NB_USER
@@ -47,3 +48,4 @@ USER jupyter
 ENV NB_USER=jupyter \
     NB_UID=9999
 ENV HOME=/home/$NB_USER
+

--- a/pims-r/Dockerfile
+++ b/pims-r/Dockerfile
@@ -5,6 +5,8 @@ FROM callysto/pims-minimal
 
 MAINTAINER Ian Allison <iana@pims.math.ca>
 
+ENV NB_USER=jovyan
+ENV HOME=/home/$NB_USER
 USER $NB_USER
 
 # R
@@ -40,4 +42,8 @@ RUN conda config --add channels r && \
 
 COPY Rprofile.site /opt/conda/lib/R/etc/Rprofile.site
 
-USER root
+USER jupyter
+# Configure environment
+ENV NB_USER=jupyter \
+    NB_UID=9999
+ENV HOME=/home/$NB_USER


### PR DESCRIPTION
This PR allows containers to be launched as a non root user. It relies on [callysto/infrastructure/pull/26](https://github.com/callysto/infrastructure/pull/26) to have a consistent uidNumber inside and outside the container. It also requires changes to the jupyterhub_config.py
