### PR TITLE
Explicitly list nbconvert to get updated version

### DIFF
--- a/pims-minimal/Dockerfile
+++ b/pims-minimal/Dockerfile
@@ -22,6 +22,7 @@ RUN conda install --yes astropy \
   markdown \
   mpfr \
   mpld3 \
+  nbconvert \
   nbval \
   nltk \
   pandas \


### PR DESCRIPTION
Address a 500 error when downloading notebooks via nbconvert.
See [CAN-91](https://jira.cybera.ca/browse/CAN-91) or
[notebook/issues/3769](https://github.com/jupyter/notebook/issues/3769)
for more details.

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>