### PR TITLE
Check for read-only home dir on container launch

### DIFF
--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Fail if the home directory is not writeable
+touch ~/writeable.txt
+rm ~/writeable.txt
+
 if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
   # launched by JupyterHub, use single-user entrypoint
   exec /usr/local/bin/start-singleuser.sh $*


### PR DESCRIPTION
Because `set -e` is in place, any command that errors will cause the whole script to fail. Therefore, using `touch` should be enough to trigger this.

It seems to work :)